### PR TITLE
Firmware version: Trim after null bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,15 @@ impl JayLink {
         let mut buf = &mut buf[..usize::from(num_bytes)];
         self.read(&mut buf)?;
 
-        Ok(String::from_utf8_lossy(buf).to_string())
+        Ok(String::from_utf8_lossy(
+            // The firmware version string returned may contain null bytes. If
+            // this happens, only return the preceding bytes.
+            match buf.iter().position(|&b| b == 0) {
+                Some(pos) => &buf[..pos],
+                None => buf,
+            },
+        )
+        .into_owned())
     }
 
     /// Reads the hardware version from the device.


### PR DESCRIPTION
Previously, the returned string may have looked like this:

    "J-Link V10 compiled Jan  7 2020 16:51:47\u{0}Copyright 2003-2015 SEGGER: www.segger.com\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}"

When converting the raw bytes from the buffer into a string, only consider characters up until the first null byte.

(Not sure if this is a bug with the buffer size or whether the J-Link simply returns this data full of null bytes.)