### PR TITLE
Don't try to select an interface for probes with fixed interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,6 +485,8 @@ impl JayLink {
         if !self.capabilities().contains(Capabilities::SELECT_IF) {
             // Pre-SELECT_IF probes only support JTAG.
             self.interfaces = Interfaces::single(Interface::Jtag);
+            self.interface = Interface::Jtag;
+
             return Ok(());
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,8 +437,11 @@ impl JayLink {
         this.fill_interfaces()?;
 
         // Probes remember the selected interface, so provide consistent defaults to avoid
-        // unreliable apps.
-        this.select_interface(Interface::Jtag)?;
+        // unreliable apps. For probes which cannot select interfaces, the JTAG interface
+        // is already selected.
+        if this.capabilities().contains(Capabilities::SELECT_IF) {
+            this.select_interface(Interface::Jtag)?;
+        }
 
         Ok(this)
     }
@@ -750,6 +753,8 @@ impl JayLink {
         if self.interface == intf {
             return Ok(());
         }
+
+        self.require_capabilities(Capabilities::SELECT_IF)?;
 
         self.require_interface_supported(intf)?;
 


### PR DESCRIPTION
Trying to select an interface will always fail for probes
with a fixed interface, so it shouldn't be done when connecting.
