### PR TITLE
Set interface to JTAG only when JTAG is actually supported. 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,9 +437,12 @@ impl JayLink {
         this.fill_interfaces()?;
 
         // Probes remember the selected interface, so provide consistent defaults to avoid
-        // unreliable apps. For probes which cannot select interfaces, the JTAG interface
-        // is already selected.
-        if this.capabilities().contains(Capabilities::SELECT_IF) {
+        // unreliable apps.
+        // - For probes which cannot select interfaces, the JTAG interface is already selected.
+        // - For probes which can, but don't support JTAG, we don't select any interface, leaving the default.
+        if this.capabilities().contains(Capabilities::SELECT_IF)
+            && this.interfaces.contains(Interface::Jtag)
+        {
             this.select_interface(Interface::Jtag)?;
         }
 


### PR DESCRIPTION
This PR depends on #30 

Fixes #31 